### PR TITLE
chore: preserve credential type array order

### DIFF
--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -207,7 +207,7 @@ export class CredentialPlugin implements IAgentPlugin {
   ): Promise<VerifiableCredential> {
     let { credential, proofFormat, keyRef, removeOriginalFields, save, now, ...otherOptions } = args
     const credentialContext = normalizeContext(credential['@context'])
-    const credentialType = processEntryToArray(credential.type, 'VerifiableCredential')
+    const credentialType = processEntryToArray(credential.type)
 
     credential = {
       ...credential,


### PR DESCRIPTION
This PR preserves the credential type array order when issuing Verifiable Credentials.

<img width="1843" alt="Screenshot 2024-11-02 at 11 01 09 AM" src="https://github.com/user-attachments/assets/874bd4fa-34f8-453c-9808-a89986907355">
